### PR TITLE
Improve-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      skip:
+        description: 'Test cases to skip (format: LIBNAME.TESTCASE or LIBNAME(...TESTCASE))'
+        required: false
+        type: string
   push:
     branches: [ main ]
     paths:
@@ -14,40 +19,108 @@ on:
       - "testkit.luau"
 
 jobs:
-  run-tests:
+  parse_skips:
+    name: Parse skips
+    if: inputs.skip
+    runs-on: ubuntu-latest
+    concurrency:
+      group: CI-PARSE-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    outputs:
+      skip_json: ${{ steps.main.outputs.skip_json }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: main
+        id: main
+        shell: bash
+        run: |
+          skip_json="{}"
+
+          # Remove all whitespace and then split
+          IFS=',' read -ra SKIP_ITEMS <<< "$(echo "${{ inputs.skip }}" | tr -d '[:space:]')"
+
+          for item in "${SKIP_ITEMS[@]}"; do
+            if [[ $item =~ ^([A-Za-z0-9_]+)\(([A-Za-z0-9_,]+)\)$ ]]; then
+              lib="${BASH_REMATCH[1]}"
+              IFS=',' read -ra cases <<< "${BASH_REMATCH[2]}"
+              
+              for case in "${cases[@]}"; do
+                if [[ ! $case =~ ^[A-Za-z0-9_]+$ ]]; then
+                  echo "SYNTAX ERROR INVALID CASE NAME '$case' IN LIB '$item'"
+                  exit 1
+                else
+                  skip_json=$(echo $skip_json | jq --arg lib "$lib" --arg case "$case" '. + {($lib): (.[($lib)] + [$case] | unique)}')
+                fi
+              done
+            elif [[ $item =~ ^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)$ ]]; then
+              lib="${BASH_REMATCH[1]}"
+              case="${BASH_REMATCH[2]}"
+              skip_json=$(echo $skip_json | jq --arg lib "$lib" --arg case "$case" '. + {($lib): (.[($lib)] + [$case] | unique)}')
+            else
+              echo "SYNTAX ERROR INVALID FORMAT GIVEN FOR '$item'"
+              exit 1
+            fi
+          done
+          
+          echo "skip_json=$(echo $skip_json | jq -c .)" >> $GITHUB_OUTPUT
+
+  Run:
+    needs: parse_skips
+    env:
+      SKIP_JSON: ${{ needs.parse_skips.outputs.skip_json }}
+    
     strategy:
-        fail-fast: false
-        matrix:
-          include:
-            - name: Windows x86_64
-              runner-os: windows-latest
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            runner-os: windows-latest
   
-            - name: Linux x86_64
-              runner-os: ubuntu-latest
+          - name: Linux
+            runner-os: ubuntu-latest
   
-            - name: macOS aarch64
-              runner-os: macos-14
-    name: ${{ matrix.name }}
+          - name: macOS
+            runner-os: macos-14
+    concurrency:
+      group: CI-${{ matrix.runner-os }}-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ${{ matrix.runner-os }}
+    name: ${{ matrix.name }}
         
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Setup Foreman
-        uses: Roblox/setup-foreman@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: CompeyDev/setup-rokit@v0.1.0
+      - uses: actions/checkout@v3
 
       - name: Install Toolchain
-        run: foreman install
+        run: rokit install --no-trust-check
+
+      - name: Append skips
+        if: inputs.skip
+        shell: bash
+        run: |
+          find libs -name "*test.luau" | while read -r file; do
+            echo "Running test: $file"
+            
+            # Extract lib name from filename
+            lib_name=$(basename "$file" | sed 's/\.test\.luau$//')
+            
+            skip_cases=$(echo $SKIP_JSON | jq -r --arg lib "$lib_name" '.[$lib] // [] | .[]')
+            
+            while IFS= read -r case; do
+              if [[ -n $case ]]; then
+                echo "SKIP(\"$case\")" >> "$file"
+              fi
+            done <<< "$skip_cases"
+          done
 
       - name: Run Tests
         shell: bash
         run: |
           find libs -name "*test.luau" | while read -r file; do
             # append the finish call to the end of the file, because im lazy!!
-            echo -e "\n\nassert(FINISH())" >> "$file"
+            echo "\n\nassert(FINISH())" >> "$file"
 
             lune run $file
           done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - "docs/**"
 
+concurrency:
+  group: DOCS-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,14 @@ on:
       tag_name:
         description: 'Tag for this release (e.g., v1.0.0)'
         required: true
+        type: string
 
 permissions:
   contents: write
+
+concurrency:
+  group: RELEASE-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   make_draft:
@@ -19,8 +24,11 @@ jobs:
     outputs:
       release_id: ${{ steps.create_draft.outputs.release_id }}
       version: ${{ steps.get_version.outputs.version }}
+    env:
+      version: placeholder
 
     steps:
+      - uses: ./.github/workflows/ci.yml
       - uses: actions/checkout@v3
 
       - name: Get version
@@ -33,6 +41,7 @@ jobs:
             version=${{ github.event.inputs.tag_name }}
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_ENV
           echo "FOUND VERSION $version"
       
       - name: Create draft
@@ -40,17 +49,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ ${{ github.event_name }} == 'release' ]]; then
-            # Convert existing release to draft
-            release_id=$(gh release edit ${{ steps.get_version.outputs.version }} --draft | grep -oP 'releases/tag/\K.*')
+          if gh release view ${{ env.version }}; then
+            gh release edit ${{ env.version }} --draft
           else
-            if gh release edit ${{ steps.get_version.outputs.version }}; then
-              release_id=$(gh release edit ${{ steps.get_version.outputs.version }} --draft | grep -oP 'releases/tag/\K.*')
-            else
-              # Create new draft release
-              release_id=$(gh release create ${{ steps.get_version.outputs.version }} --draft --title "${{ steps.get_version.outputs.version }}" --generate-notes | grep -oP 'releases/tag/\K.*')
-            fi
+            gh release create ${{ env.version }} --draft --title "${{ env.version }}" --generate-notes
           fi
+          release_id=$(gh release view v2.1.0 --json id -q ".id")
+
           echo "release_id=$release_id" >> $GITHUB_OUTPUT
 
   build:
@@ -62,14 +67,6 @@ jobs:
       version: ${{needs.make_draft.outputs.version}}
     steps:
       - uses: actions/checkout@v3
-
-      - name: Setup Foreman
-        uses: Roblox/setup-foreman@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Toolchain
-        run: foreman install
 
       - name: Run script
         run: lune run release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
       version: placeholder
 
     steps:
-      - uses: ./.github/workflows/ci.yml
       - uses: actions/checkout@v3
+
+      - name: Run CI
+        uses: ./.github/workflows/ci.yml
 
       - name: Get version
         id: get_version
@@ -66,8 +68,12 @@ jobs:
       release_id: ${{needs.make_draft.outputs.release_id}}
       version: ${{needs.make_draft.outputs.version}}
     steps:
+      - uses: CompeyDev/setup-rokit@v0.1.0
       - uses: actions/checkout@v3
 
+      - name: Install Toolchain
+        run: rokit install --no-trust-check
+        
       - name: Run script
         run: lune run release
 


### PR DESCRIPTION
* improve ci workflow, with over complex skip input (as a more future proof solution for skipping tests and testcases as retryer's tests currently will infintely yield because of a lune bug)
* add concurrency to docs workflow
* add type for tag name arg in release workflow
* simplify create draft step of release workflow
* remove usages of foreman, and replace with rokit